### PR TITLE
Use radix 2 instead

### DIFF
--- a/LogicExecutor.js
+++ b/LogicExecutor.js
@@ -98,13 +98,13 @@ class LogicExecutor {
         	        al = (a>>>b).toString(2);
         	        ah = (Math.floor(a / 4294967296)>>>0).toString(2);
         	        ah = ah.slice(1);
-        	        return parseInt(ah+al);
+        	        return parseInt(ah+al,2);
         	    case "shl":
         	        if(b<0) return this.doOp("shr",a,0-b);
         	        sign = a < 0 ? "1" : "0";
         	        al = (a>>>0).toString(2);
         	        ah = (Math.floor(a / 4294967296)>>>0).toString(2).slice(0-b);
-        	        return ah+al+sign.repeat(b);
+        	        return parseInt(ah+al+sign.repeat(b),2);
         	    // I originally planned to put condition and logic ops here as well - but my sanity ran out. DO YOU SEE THESE BITSHIFTS?
         	    default:
         	        return null;


### PR DESCRIPTION
Use binary (radix 2) instead of decimal (radix 10) for `shr` and `shl`.